### PR TITLE
Add AGENTS guidelines for PackageTools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,7 @@ Welcome to the **PackageTools** repository. This repository hosts an R package t
 
 ## Dependencies
 The package's core functionality depends only on the CRAN packages declared in `DESCRIPTION`.
-It does **not** require any additional `@vertesy` libraries. If you encounter
-example scripts that mention other repositories from the same author, those
-references are optional and can be skipped unless you wish to explore them.
+It does not require any additional `@vertesy` libraries. If you encounter a dependency, raise this problem.
 
 ## For Newcomers
 - Start by reading `README.md` for an overview of available tools.


### PR DESCRIPTION
## Summary
- add root AGENTS file with repository overview, testing instructions, and dependency notes
- clarify that `PackageTools` relies only on CRAN packages and has no required `@vertesy` dependencies

## Testing
- `R CMD check .` *(fails: command not found: R)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.147 8080])*
- `apt-get install -y r-base` *(fails: Unable to locate package r-base)*

------
https://chatgpt.com/codex/tasks/task_e_68948ee25c7c832c929b60d743a487f1