### PR TITLE
Fix documentation typos

### DIFF
--- a/R/DependencyTools.R
+++ b/R/DependencyTools.R
@@ -103,7 +103,7 @@ map_functions_to_packages <- function(
 #'                  Default: None, a valid function name must be provided.
 #' @param package_name The name of the package containing the function.
 #'                     Default: None, a valid package name must be provided.
-#' @param ls_fun_names_to_map A list function names mapped to their source package.
+#' @param ls_fun_names_to_map A list of function names mapped to their source package.
 #'                        Default: None, a valid mapping must be provided.
 #' @param exclude_packages A vector of package names whose functions should be excluded from the analysis.
 #'                         Default: c("base", "utils", "methods", "stats").
@@ -256,11 +256,11 @@ filter_conflicts <- function(dependencies) {
 }
 
 # _____________________________________________________________________________________________
-#' @title Count and print the number of functions results
+#' @title Count and Print the Number of Functions in Results
 #'
 #' @description Private function to count and print the number of functions in results ("dependencies").
 #'
-#' @param dependencies Result from above functions dependencies
+#' @param dependencies Results from the above functions' dependencies
 #' @return Nothing.
 .count_and_print_function_summary <- function(dependencies) {
   counts <- sapply(dependencies, function(pkg_deps) length(pkg_deps))
@@ -286,14 +286,14 @@ filter_conflicts <- function(dependencies) {
 #'
 #' @param graph An igraph object representing a network graph. Default: None (must be provided).
 #' @param direction The direction of the flowchart. One of 'TB', 'TD', 'BT', 'RL', 'LR'. Default: 'LR'.
-#' @param node_shape The shape of the nodes in the flowchart. One of 'round', 'default'. Default: 'round'.
+#' @param node_shape The shape of the nodes in the flowchart. One of 'round' or 'default'. Default: 'round'.
 #' @param copy_to_clipboard Whether to copy the resulting Mermaid.js code to the clipboard. Default: TRUE.
-#' @param openMermaid open www.mermaid.live website? Default: TRUE.
+#' @param openMermaid Open the www.mermaid.live website? Default: TRUE.
 #' @param add_subgraph_template Add subgraph template? Default: TRUE.
 #' @param add_embedding_comments Add lines for direct markdown embedding of the code,
 #' formatted as mermaid comments. The `%%` must be removed in the `.md` file.
-#' @param pkg_path_for_scripts_as_subgraphs Do you want to add it to subgraphs? Provide the package
-#'  path for scripts represented as subgraphs."
+#' @param pkg_path_for_scripts_as_subgraphs Add scripts as subgraphs? Provide the package
+#'  path for scripts represented as subgraphs.
 #' @return A string containing the Mermaid.js code for the flowchart.
 #' @examples
 #' result <- pkgnet::CreatePackageReport("YourPackage")

--- a/R/DocumentationTools.R
+++ b/R/DocumentationTools.R
@@ -21,7 +21,7 @@
 #' @title Create R Package from Configuration
 #'
 #' @description Automate the creation of an R package from a configuration file.
-#' This function automates the creation of an R package by sourcinÏg a configuration file
+#' This function automates the creation of an R package by sourcing a configuration file
 #' from the specified package directory. It assumes the presence of a `config.R` file in
 #' the `Development` subdirectory of the package.
 #'
@@ -29,7 +29,7 @@
 #' @param config_file The configuration file name within the package's Development directory.
 #'                    Default: 'config.R'.
 #' @param update_citation Whether to update the CITATION file. Default: FALSE.
-#' @param backup_r_script Whether to backup the previous r script into another file. Default: FALSE.
+#' @param backup_r_script Whether to back up the previous R script into another file. Default: FALSE.
 #' @param dev_folder The name of the development folder. Default: 'Development'.
 #'
 #' @return None

--- a/R/Miscellaneous.R
+++ b/R/Miscellaneous.R
@@ -120,7 +120,7 @@ checkScriptEnv_v1 <- function(path, input.variables, exclude_var = c("i", "path"
 #'               Valid options are 'experimental', 'active', 'archive', and 'hibernate'.
 #'               Default: 'experimental'.
 #' @param prefix The URL prefix for the badge images.
-#'               Default: "https:,//raw.githubusercontent.com/vertesy/TheCorvinas/master/GitHub/Badges/".
+#'               Default: "https://raw.githubusercontent.com/vertesy/TheCorvinas/master/GitHub/Badges/".
 #' @param copy_to_clipboard Logical. If TRUE, the badge Markdown code is copied to the clipboard.
 #'
 #' @return The function does not return a value but copies the relevant badge Markdown code to the clipboard.

--- a/R/PackageSetupTools.R
+++ b/R/PackageSetupTools.R
@@ -21,7 +21,7 @@
 #' @param package_name Name of the new package. Default: 'NewPackage'.
 #' @param packages_path Path to the packages directory. Default: '~/GitHub/Packages/'.
 #' @param template_pkg Name of the template package. Default: 'PackageTools'.
-#' @param place_holder place holder string to replace. Default: 'TEMPLATE'.
+#' @param place_holder Placeholder string to replace. Default: 'TEMPLATE'.
 #'
 #' @return None
 #' @export

--- a/R/PackageTools.R
+++ b/R/PackageTools.R
@@ -24,7 +24,7 @@
 #'             Default: None, a valid file path must be provided.
 #' @param output_file Path to the output file where the summary will be written.
 #'                    Default: "1list.of.functions.in.YOURFILE.md"
-#' @param fun_header_level header level for functions. Default: "####"
+#' @param fun_header_level Header level for functions. Default: "####"
 #' @param open_results Open resulting file? Default: TRUE.
 #' @return This function does not return a value; it writes output to the specified file.
 #' @examples
@@ -393,8 +393,8 @@ checkGlobalVars <- function(f, silent = FALSE, warn = TRUE) {
 #' expressions to differentiate between code and comment lines and to extract the names of sourced files.
 #'
 #' @param file_path The path to the file to be analyzed.
-#' @param pattern The regular expression pattern used to identify comment lines. Default: `^\\s*#"`.
-#' @param patter_sourced_files The regular expression pattern used to identify lines where files are sourced.
+#' @param pattern The regular expression pattern used to identify comment lines. Default: `^\\s*#`.
+#' @param pattern_sourced_files The regular expression pattern used to identify lines where files are sourced.
 #' Default: `source\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)`.
 #'
 #' @return A list containing the number of lines of code, the number of comment lines,
@@ -405,11 +405,11 @@ checkGlobalVars <- function(f, silent = FALSE, warn = TRUE) {
 #' source_file_stats_analyzer("path/to/your/script.R")
 #' @export
 source_file_stats_analyzer <- function(file_path, pattern = "^\\s*#",
-                                       patter_sourced_files = "source\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)") {
+                                       pattern_sourced_files = "source\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)") {
   # Input argument assertions
   stopifnot(is.character(file_path), length(file_path) == 1)
   stopifnot(is.character(pattern), length(pattern) == 1)
-  stopifnot(is.character(patter_sourced_files), length(patter_sourced_files) == 1)
+  stopifnot(is.character(pattern_sourced_files), length(pattern_sourced_files) == 1)
 
   lines <- readLines(file_path, warn = FALSE)
   idx.lines.comment <- grepl(pattern, lines)
@@ -419,7 +419,7 @@ source_file_stats_analyzer <- function(file_path, pattern = "^\\s*#",
   code.lines <- lines[!idx.lines.comment & nzchar(lines)]
 
   # Extracting files sourced within this file
-  sourced_files <- regmatches(code.lines, regexec(patter_sourced_files, code.lines))
+  sourced_files <- regmatches(code.lines, regexec(pattern_sourced_files, code.lines))
   sourced_files <- unlist(lapply(sourced_files, function(x) if (length(x) > 1) x[2] else NA))
   sourced_files <- unique(sourced_files[!is.na(sourced_files)])
   print(sourced_files)

--- a/R/ReplacementTools.R
+++ b/R/ReplacementTools.R
@@ -133,15 +133,15 @@ replace_tf_with_true_false <- function(file_path, output_path = file_path,
 
 #' @title Replace Short Function Calls with Full Names in an R Script
 #'
-#' @description Reads an R script file and replaces instances of `length(` with `length(` and `p0` with `paste0(`.
+#' @description Reads an R script file and replaces instances of `l(` with `length(` and `p0(` with `paste0(`.
 #' It supports a strict mode to ensure accurate replacements.
 #'
 #' @param file_path A string representing the path to the R script file.
 #' @param output_path A string representing the path to save the modified R script.
 #' Default is the same as `file_path`.
 #' @param strict_mode A boolean flag to determine the strictness of the matches.
-#' If `TRUE`, matches `length(` and `p0` only when they're not part of larger alphanumeric strings.
-#' If `FALSE`, all instances of `length(` and `p0` are replaced.
+#' If `TRUE`, matches `l(` and `p0(` only when they're not part of larger alphanumeric strings.
+#' If `FALSE`, all instances of `l(` and `p0(` are replaced.
 #'
 #' @return None
 #' @importFrom stringr str_detect
@@ -169,9 +169,9 @@ replace_short_calls <- function(file_path, output_path = file_path, strict_mode 
 
 
 # _____________________________________________________________________________________________
-#' @title Replace length() with length() in an R Script
+#' @title Replace l() with length() in an R Script
 #'
-#' @description This function reads an R script file and replaces instances of `length(` with `length(`.
+#' @description This function reads an R script file and replaces instances of `l(` with `length(`.
 #' It supports a strict mode to ensure accurate replacement.
 #'
 #' @param file_path A string representing the path to the R script file.
@@ -256,7 +256,7 @@ replace_l_with_length <- function(file_path, output_path = file_path, strict_mod
 # _____________________________________________________________________________________________
 #' @title Safely Replace Short Function Calls in a Line of R Script
 #'
-#' @description Safely replaces instances of `length(` with `length(` and `p0` with `paste0(` in a given line of R script.
+#' @description Safely replaces instances of `l(` with `length(` and `p0(` with `paste0(` in a given line of R script.
 #' Operates in strict mode to ensure that replacements are made only when not part of a larger word or variable name.
 #'
 #' @param line A single line from an R script.
@@ -269,11 +269,11 @@ replace_l_with_length <- function(file_path, output_path = file_path, strict_mod
 #' @export
 .safely_replace_calls <- function(line, strict_mode) {
   if (strict_mode) {
-    # Replace 'length(' and 'p0' when they are likely function calls
+    # Replace 'l(' and 'p0(' when they are likely function calls
     modified_line <- gsub("(^|[^a-zA-Z0-9_])l\\(", "\\1length(", line)
     modified_line <- gsub("(^|[^a-zA-Z0-9_])p0\\(", "\\1paste0(", modified_line)
   } else {
-    # Replace all instances of 'length(' and 'p0'
+    # Replace all instances of 'l(' and 'p0('
     modified_line <- gsub("\\bl\\(", "length(", line, perl = TRUE)
     modified_line <- gsub("\\bp0\\(", "paste0(", modified_line, perl = TRUE)
   }
@@ -282,10 +282,10 @@ replace_l_with_length <- function(file_path, output_path = file_path, strict_mod
 }
 
 # _____________________________________________________________________________________________
-#' @title Safely Replace length() with length() in a Line of R Script
+#' @title Safely Replace l() with length() in a Line of R Script
 #'
-#' @description This function safely replaces instances of `length(` with `length(` in a given line of R script.
-#' It can operate in a strict mode, which ensures that `length(` is replaced only when it is not part of a larger word
+#' @description This function safely replaces instances of `l(` with `length(` in a given line of R script.
+#' It can operate in a strict mode, which ensures that `l(` is replaced only when it is not part of a larger word
 #' or variable name.
 #'
 #' @param line A single line from an R script.
@@ -298,10 +298,10 @@ replace_l_with_length <- function(file_path, output_path = file_path, strict_mod
 #' @export
 .safely_replace_l <- function(line, strict_mode) {
   if (strict_mode) {
-    # Replace 'length(' when it is likely a function call
+    # Replace 'l(' when it is likely a function call
     modified_line <- gsub("(^|[^a-zA-Z0-9_])l\\(", "\\1length(", line)
   } else {
-    # Replace all instances of 'length('
+    # Replace all instances of 'l('
     modified_line <- gsub("\\bl\\(", "length(", line, perl = TRUE)
   }
 

--- a/R/RoxygenTools.R
+++ b/R/RoxygenTools.R
@@ -115,7 +115,7 @@ find_package_calls <- function(body_content, pattern = "\\b\\w+::[\\w.]+\\b", ex
 #' Default: Suffix for added lines is "ADDED_BY_add_importFrom_statements".
 #' @param file_content A character vector representing the lines of an R script.
 #' @param bodies A list of function body line numbers.
-#' @param suffix A string suffix to add to the` @importFrom` lines.
+#' @param suffix A string suffix to add to the `@importFrom` lines.
 #' Default: "ADDED_BY_add_importFrom_statements".
 #' @param exclude_packages Packages to exclude from adding `@importFrom` statements.
 #' Default: empty character vector.


### PR DESCRIPTION
## Summary
- fix wording in package creation helper
- correct default GitHub badge URL
- clean up multiple function docs and parameter names

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `R CMD check .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a161c960832cb082f26f0d11577a