### PR TITLE
Fix metadata and doc typos

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
-title: vertesy/Seurat.utils
-version: v0.7.9
+title: PackageTools
+version: 0.7.9
 message: >-
   If you use this software, please cite it using these metadata.
 type: software

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Version: 0.7.9
 Authors@R: 
     person("Abel", "Vertesy", , "av@imba.oeaw.ac.at", role = c("aut", "cre"))
 Author: Abel Vertesy <av@imba.oeaw.ac.at> [aut, cre]
-Description: PackageTools is a collection of utility functions for code
-    base statistics & and dependencies.
+Description: PackageTools is a collection of utility functions for
+    codebase statistics and dependencies.
 License: GPL-3 + file LICENSE
 BugReports: https://github.com/vertesy/PackageTools/issues
 Imports: 
@@ -19,6 +19,6 @@ Imports:
     usethis,
     xfun
 Encoding: UTF-8
-Packaged: 2024-10-24 10:39:44.198975
+Packaged: 2025-08-07 13:01:22 UTC; root
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1

--- a/Examples/Usage.of.DocumentationTools.R
+++ b/Examples/Usage.of.DocumentationTools.R
@@ -1,10 +1,3 @@
-
-
-'~/GitHub/Packages/PackageTools/R/PackageTools.R'
 # checkPackageDependencies('~/GitHub/Packages/PackageTools')
-
 PackageTools::extract_package_dependencies('~/GitHub/Packages/PackageTools')
-
-
-
 

--- a/Examples/Usage.of.PackageTools.R
+++ b/Examples/Usage.of.PackageTools.R
@@ -44,9 +44,8 @@ scripts = c(
   # '~/GitHub/Packages/DatabaseLinke.R/R/DatabaseLinke.R',
 
   '~/GitHub/Packages/SCP.tools/R/SCP.functions.R',
-
-
-  "")
+  ""
+)
 
 
 for (i in 1:length(scripts)) {

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Filter out functions with no dependencies / only with dependencies:
 
 ```R
 funs_with_deps <- filter_dependencies(dependencies, include_only_with_deps = TRUE)
-funs_no_deps <- filter_dependencies(dependencies, include_only_with_deps = TRUE)
+funs_no_deps <- filter_dependencies(dependencies, include_only_with_deps = FALSE)
 ```
 
 ### Identifying Conflicts
@@ -137,7 +137,7 @@ For `filter_dependencies` and `filter_conflicts`, the output will be similar but
 ------------------------------
 
 # 3. RoxygenTools
-`Currenly limited in scope`
+`Currently limited in scope`
 ## Goal: Adding @importFrom Statements to Roxygen
 
 This R package provides functionality to automatically add `@importFrom` statements to the Roxygen documentation of functions in an R script. It scans for functions called using the `::` operator within function bodies and appends the corresponding `@importFrom` directives to the Roxygen blocks above the function definitions.
@@ -340,7 +340,7 @@ Updated: 2024/01/25 15:22
 
 - #### 1 `document_and_create_package()`
 
-  Create R Package from Configuration. Automate the creation of an R package from a configuration file.  This function automates the creation of an R package by sourcinÏg a configuration file  from the specified package directory. It assumes the presence of a `config.R` file in  the `Development` subdirectory of the package. 
+  Create R Package from Configuration. Automate the creation of an R package from a configuration file.  This function automates the creation of an R package by sourcing a configuration file  from the specified package directory. It assumes the presence of a `config.R` file in  the `Development` subdirectory of the package.
 
 - #### 2 `.parse_description()`
 
@@ -348,7 +348,7 @@ Updated: 2024/01/25 15:22
 
 - #### 3 `.update_citation_file()`
 
-  Helper function to update the CITATION file of a package.. Update the CITATION.cff file of a package based on its version. 
+  Helper function to update the CITATION file of a package. Update the CITATION.cff file of a package based on its version.
 
 
 
@@ -388,13 +388,13 @@ Updated: 2024/01/25 15:22
 
 Updated: 2024/01/25 15:22
 
-- #### 1 `# from()`
+- #### 1 `from()`
 
   Check Script Environment. Checks if all functions and variables called in a script are found in a specified environment.               Optionally replaces missing function calls in the script with their fully qualified names. 
 
 - #### 2 `copy_github_badge()`
 
-  .   This function copies the Markdown code for a GitHub badge to the clipboard based on the  specified status. It supports four statuses: 'experimental', 'active', 'archive', and  'hibernate'. 
+  This function copies the Markdown code for a GitHub badge to the clipboard based on the specified status. It supports four statuses: 'experimental', 'active', 'archive', and 'hibernate'.
 
 
 


### PR DESCRIPTION
## Summary
- update package name in citation metadata
- correct description grammar and packaged date
- clean up README and examples by fixing typos and code snippets
- restore placeholder element in example script to avoid trailing comma

## Testing
- `R CMD check .` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y r-base` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6894a16757c8832c9e8501558bc1c3cc