### PR TITLE
Fix namespace checks and clipboard handling

### DIFF
--- a/R/DependencyTools.R
+++ b/R/DependencyTools.R
@@ -369,7 +369,7 @@ convert_igraph_to_mermaid <- function(
 
   stopifnot("Mermaid.js code should be a non-empty string" = is.character(mermaid_code) && nchar(mermaid_code) > 0)
 
-  if (copy_to_clipboard & require(clipr)) clipr::write_clip(mermaid_code)
+  if (copy_to_clipboard && requireNamespace("clipr", quietly = TRUE)) clipr::write_clip(mermaid_code)
 
   print("Check output on https://mermaid.live")
   if (openMermaid) browseURL("https://mermaid.live")

--- a/R/DocumentationTools.R
+++ b/R/DocumentationTools.R
@@ -216,7 +216,7 @@ extract_package_dependencies <- function(package_dir, output_file = "Development
     f.deps <- NCmisc::list.functions.in.file(filename = file)
 
     # Copying to clipboard or printing to console
-    if (copy_to_clipboard & require(clipr)) clipr::write_clip(f.deps) else print(f.deps)
+    if (copy_to_clipboard && requireNamespace("clipr", quietly = TRUE)) clipr::write_clip(f.deps) else print(f.deps)
 
     # Writing to dependencies file
     sink(file = depFile, append = TRUE)

--- a/R/Miscellaneous.R
+++ b/R/Miscellaneous.R
@@ -142,7 +142,7 @@ copy_github_badge <- function(status = "experimental",
   markdown_text <- paste0("![status: ", status, "](", badge_link, ")")
 
   # Copy to clipboard, or return the Markdown text
-  if (copy_to_clipboard & require(clipr)) clipr::write_clip(markdown_text) else message(markdown_text)
+  if (copy_to_clipboard && requireNamespace("clipr", quietly = TRUE)) clipr::write_clip(markdown_text) else message(markdown_text)
 
 }
 

--- a/R/PackageTools.R
+++ b/R/PackageTools.R
@@ -333,8 +333,8 @@ checkGlobalVarsInPackage <- function(packageName, warn = TRUE) {
   funcNames <- all_funs(packageName)
 
   # Check global variables for each function
-  funzy <- lapply(funcNames, get)
-  for (i in seq(funzy)) {
+  funzy <- lapply(funcNames, function(fn) get(fn, envir = asNamespace(packageName)))
+  for (i in seq_along(funzy)) {
     message("----------------")
     message(funcNames[i])
     checkGlobalVars(f = funzy[[i]], warn = warn)


### PR DESCRIPTION
## Summary
- Ensure `checkGlobalVarsInPackage()` pulls functions from package namespace and iterates safely
- Use `requireNamespace()` with short-circuit checks for optional clipboard operations

## Testing
- `R -q -e 'devtools::document()'` *(fails: R not installed)*
- `R CMD check .` *(fails: R not installed)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b8c3407c832c895e4e3cc4414ec4